### PR TITLE
fix: indentation is too wide

### DIFF
--- a/src/bin/fish_indent.rs
+++ b/src/bin/fish_indent.rs
@@ -54,7 +54,7 @@ use fish::{
 
 // The number of spaces per indent isn't supposed to be configurable.
 // See discussion at https://github.com/fish-shell/fish-shell/pull/6790
-const SPACES_PER_INDENT: usize = 4;
+const SPACES_PER_INDENT: usize = 2;
 
 /// Note: this got somewhat more complicated after introducing the new AST, because that AST no
 /// longer encodes detailed lexical information (e.g. every newline). This feels more complex


### PR DESCRIPTION
## Description

If indentation isn't meant to be configurable, guess I have to build my own version ¯\_(ツ)_/¯

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
